### PR TITLE
Remove nav item and rename sample post

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -49,17 +49,3 @@ header:
       # @end locale config
     url: /about.html
 
-  - titles:
-      en      : &EN       LLM History
-      en-GB   : *EN
-      en-US   : *EN
-      en-CA   : *EN
-      en-AU   : *EN
-      zh-Hans : &ZH_HANS  LLM的发展史
-      zh      : *ZH_HANS
-      zh-CN   : *ZH_HANS
-      zh-SG   : *ZH_HANS
-      zh-Hant : &ZH_HANT  LLM的發展史
-      zh-TW   : *ZH_HANT
-      zh-HK   : *ZH_HANT
-    url: /llm-history.html

--- a/_posts/2022-11-08-title.md
+++ b/_posts/2022-11-08-title.md
@@ -1,5 +1,5 @@
 ---
-title: TeXt - MathJax
+title: LLM history
 layout: article
 key: 20170707
 tags: TeXt


### PR DESCRIPTION
## Summary
- drop the LLM History navigation link
- rename the sample post from **TeXt - MathJax** to **LLM history**

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853511f0c5c8332b5c1f84c0c811922